### PR TITLE
refactored collectAndSendTweets, added to home route.

### DIFF
--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -1,3 +1,7 @@
+const jwtSecret = process.env.JWT_SECRET;
+const jwt = require('jsonwebtoken');
+const collectAndSendTweets = require('./requesttoken.js').collectAndSendTweets;
+
 module.exports = {
     method: 'GET',
     path: '/',
@@ -6,21 +10,12 @@ module.exports = {
         if (!request.state.access_token) {
           reply.redirect('/login');
         } else {
-          reply.view('logged-in');
+          const token = request.state.access_token;
+          const decodedDataToSend = jwt.verify(token, jwtSecret);
+          collectAndSendTweets(decodedDataToSend, (viewData) => {
+            reply.view('logged-in', viewData);
+          });
         }
       }
     }
 };
-
-
-
-
-//
-//
-// module.exports = {
-//   path: '/',
-//   method: 'GET',
-//   handler: (request, reply) => {
-//     reply.view('home');
-//   }
-// };

--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -2,6 +2,8 @@ const jwtSecret = process.env.JWT_SECRET;
 const jwt = require('jsonwebtoken');
 const collectAndSendTweets = require('./requesttoken.js').collectAndSendTweets;
 
+// Check if cookie is present. If present, run collectAndSendTweets, passing decoded
+// JWT as Data for the request. If cookie is not present, redirect to login page.
 module.exports = {
     method: 'GET',
     path: '/',

--- a/lib/routes/login.js
+++ b/lib/routes/login.js
@@ -1,7 +1,0 @@
-module.exports = {
-  path: '/',
-  method: 'GET',
-  handler: (request, reply) => {
-    reply.view('home');
-  }
-};

--- a/lib/routes/requesttoken.js
+++ b/lib/routes/requesttoken.js
@@ -17,7 +17,7 @@ const oauth = {
 let oauthToken = '';
 let oauthTokenSecret = '';
 
-// Runs before login page is loaded, gets a requestToken and sets it to the 
+// Run before login page is loaded, getting a requestToken and setting it to the 
 // URL of the link of the 'Login with Twitter' button on the login page. On 
 // clicking the button, the user is redirected to Twitter to authorise our app.
 const requestTokenPath = {
@@ -35,8 +35,8 @@ const requestTokenPath = {
   }
 };
 
-// After authorising on twitter, user comes to this endpoint: we grab the access token 
-// from the request, and 
+// Grab the relevant parts of their request and make a final request to Twitter for 
+// the access key. (User is redirected to this endpoint after authorising on Twitter)
 const requestTokenAccess = {
   path: '/signin-with-twitter',
   method: 'GET',
@@ -45,8 +45,8 @@ const requestTokenAccess = {
     oauth.token = authReqData.oauth_token;
     oauth.token_secret = oauthTokenSecret;
     oauth.verifier = authReqData.oauth_verifier;
-
     const accessTokenUrl = 'https://api.twitter.com/oauth/access_token';
+
     Req.post({ url: accessTokenUrl, oauth: oauth }, (err, response, body) => {
       const authenticatedData = querystring.parse(body);
       const dataToSend = {
@@ -65,7 +65,8 @@ const requestTokenAccess = {
   }
 };
 
-// Runs with a callback from inside requestTokenAccess. 
+// Add our env keys to dataToSend param, make a request for 10 tweets. Map the
+// tweets to get relevant values and return object containing them in callback
 const collectAndSendTweets = (dataToSend, callback) => {
 
   const apiURL = 'https://api.twitter.com/1.1/statuses/home_timeline.json' + '?' + 

--- a/lib/routes/requesttoken.js
+++ b/lib/routes/requesttoken.js
@@ -49,17 +49,16 @@ const requestTokenAccess = {
     const accessTokenUrl = 'https://api.twitter.com/oauth/access_token';
     Req.post({ url: accessTokenUrl, oauth: oauth }, (err, response, body) => {
       const authenticatedData = querystring.parse(body);
+      const dataToSend = {
+        token: authenticatedData.oauth_token,
+        token_secret: authenticatedData.oauth_token_secret,
+        screen_name: authenticatedData.screen_name
+      };
       
-      collectAndSendTweets(authenticatedData, (viewData) => {
+      const jwtToken = jwt.sign(dataToSend, jwtSecret);
 
-        const jwtToken = jwt.sign({
-          token: authenticatedData.oauth_token,
-          token_secret: authenticatedData.oauth_token_secret,
-          twitter_handle: authenticatedData.screen_name
-        }, jwtSecret);
-
+      collectAndSendTweets(dataToSend, (viewData) => {
         reply.view('logged-in', viewData).state('access_token', jwtToken);
-
       });
 
     });    
@@ -67,18 +66,14 @@ const requestTokenAccess = {
 };
 
 // Runs with a callback from inside requestTokenAccess. 
-const collectAndSendTweets = (authenticatedData, callback) => {
+const collectAndSendTweets = (dataToSend, callback) => {
 
   const apiURL = 'https://api.twitter.com/1.1/statuses/home_timeline.json' + '?' + 
-    querystring.stringify({screen_name: authenticatedData.screen_name, count: 10});
+              querystring.stringify({screen_name: dataToSend.screen_name, count: 10});
 
-  const dataToSend = {
-    consumer_key: CONSUMER_KEY,
-    consumer_secret: CONSUMER_SECRET,
-    token: authenticatedData.oauth_token,
-    token_secret: authenticatedData.oauth_token_secret
-  };
-
+  dataToSend.consumer_key = process.env.CONSUMER_KEY;
+  dataToSend.consumer_secret = process.env.CONSUMER_SECRET;
+    
   Req.get({url: apiURL, oauth: dataToSend, json:true}, (err, response, body) => {
     
     const mapTweets = body.map((tweet) => {
@@ -90,7 +85,7 @@ const collectAndSendTweets = (authenticatedData, callback) => {
     });
 
     callback({
-      username: authenticatedData.screen_name,
+      username: dataToSend.screen_name,
       tweets: mapTweets
     });
   });
@@ -98,5 +93,6 @@ const collectAndSendTweets = (authenticatedData, callback) => {
 
 module.exports = {
   requestTokenPath: requestTokenPath,
-  requestTokenAccess: requestTokenAccess
+  requestTokenAccess: requestTokenAccess,
+  collectAndSendTweets: collectAndSendTweets
 };

--- a/lib/routes/signIn.js
+++ b/lib/routes/signIn.js
@@ -1,8 +1,0 @@
-// module.exports = {
-//   path: '/signin-with-twitter',
-//   method: 'GET',
-//   handler: (request, reply) => {
-//     console.log(request.params);
-//     reply.view('logged-in');
-//   }
-// };


### PR DESCRIPTION
Refactored collectAndSendTweets to make it reusable in other functions. Now dataToSend is the same everywhere it is used (it is also what is encoded in the JWT). Also implemented this in the home route, passing in the decoded JWT token. 

Now the home page should either redirect to login (if not logged in with twitter) or load tweets directly (if already logged in with twitter).